### PR TITLE
GPII-3848: Fix the GPII connector test.

### DIFF
--- a/tests/GpiiConnectorTestDefs.js
+++ b/tests/GpiiConnectorTestDefs.js
@@ -55,7 +55,7 @@ gpii.tests.gpiiConnector.testDefs = {
             gpii.tests.gpiiConnector.getSettingUpdateMessage(DPIScalePath, 2)
         ]
     }, {
-        event: "{that}.app.qss.events.onSettingUpdated",
+        event: "{that}.app.gpiiConnector.events.onSettingUpdated",
         listener: "jqUnit.assertDeepEq",
         args: [
             "The setting which was updated in the PSP is correct",

--- a/tests/IntegrationTests.js
+++ b/tests/IntegrationTests.js
@@ -240,6 +240,6 @@ gpii.tests.app.bootstrapServer([
     fluid.copy(gpii.tests.siteConfigurationHandler.testDefs),
     fluid.copy(gpii.tests.storage.testDefs),
     fluid.copy(gpii.tests.userErrorsHandler.testDefs),
-    // fluid.copy(gpii.tests.gpiiConnector.testDefs),  // should be changed to match the new specification
+    fluid.copy(gpii.tests.gpiiConnector.testDefs),  // should be changed to match the new specification
     fluid.copy(gpii.tests.webview.testDefs)
 ]);


### PR DESCRIPTION
I guess what confused you was both `qss` and `gpiiConnector` have their own `onSettingUpdated` events and there isn't a connection between them. You might be clearer about whether a connection should be made or having separate `onSettingUpdated` events is desired.