### PR TITLE
GPII-3730: Fix for 1.3.x branch

### DIFF
--- a/src/renderer/qssWidget/css/qssMenuWidget.css
+++ b/src/renderer/qssWidget/css/qssMenuWidget.css
@@ -147,5 +147,5 @@
 /* CSS specific for the color wheel footertip */
 .colorWheelTip {
     position: relative;
-    bottom: 50px;
+    bottom: 10px;
 }


### PR DESCRIPTION
This makes the text move below the buttons, to work with the [morphic-1.3.x branch](https://github.com/GPII/gpii-app/tree/morphic-1.3.x) (but it looks bad on this branch).

